### PR TITLE
Cloud height tweaks

### DIFF
--- a/RVE/EVE/Atmosphere/clouds.cfg
+++ b/RVE/EVE/Atmosphere/clouds.cfg
@@ -4,7 +4,7 @@ EVE_ATMOSPHERE
 	{
 		Kerbin-cloudsHigh
 		{
-			altitude = 8000
+			altitude = 9000
 			speed = 70
 			scaledOverlay = Geometry
 			layer2D
@@ -33,7 +33,7 @@ EVE_ATMOSPHERE
 		}
 		Kerbin-cloudsLow
 		{
-			altitude = 3000
+			altitude = 5000
 			speed = 30
 			scaledOverlay = Geometry
 			layer2D
@@ -62,7 +62,7 @@ EVE_ATMOSPHERE
 		}
 		Kerbin-cloudsLowest
 		{
-			altitude = 1500
+			altitude = 3500
 			speed = 16
 			scaledOverlay = Geometry
 			layer2D


### PR DESCRIPTION
I found that by spacing the clouds more and raising them further from the ground the 'pin stripping' effect was pretty much removed, and things look pretty good during ascent in OpenGL KSP win32 until about 50km altitude where concentric orange circles start to appear, and a wide green ring appears and moves towards the horizon.
