### PR TITLE
city lights, texture re-use

### DIFF
--- a/RVE/EVE/CityLights/cityLights.cfg
+++ b/RVE/EVE/CityLights/cityLights.cfg
@@ -6,7 +6,7 @@ EVE_CITY_LIGHTS
 		{
 			_CityOverlayTex = RVE/EVE/CityLights/Textures/main
 			_CityOverlayDetailScale = 450
-			_CityDarkOverlayDetailTex =
+			_CityDarkOverlayDetailTex = RVE/EVE/CityLights/Textures/detailDay
 			_CityLightOverlayDetailTex = RVE/EVE/CityLights/Textures/detailDay
 		}
 	}


### PR DESCRIPTION
with no texture, the ground is grey. by reusing the detailDay texture it looks alright, and even interacts favourably with CityLights.
