### PR TITLE
Tweak Scatterer Settings For RSS

### DIFF
--- a/scatterer/config/Settings.txt
+++ b/scatterer/config/Settings.txt
@@ -1,10 +1,10 @@
 forceOFFaniso = False
 displayInterpolatedVariables = False
-extinctionMultiplier = 1
-extinctionTint = 1
+extinctionMultiplier = 1.1
+extinctionTint = 0.65
 mapExtinctionMultiplier = 1
-mapExtinctionTint = 1
-MapViewScale = 1
+mapExtinctionTint = 0.65
+MapViewScale = 10.59
 mapExposure = 0.15
 mapAlphaGlobal = 1
 rimBlend = 20
@@ -64,6 +64,6 @@ configPoints
 		postProcessDepth = 0.7
 		postProcessExposure = 0.25
 		skyExtinctionMultiplier = 1.1
-		skyExtinctionTint = 0.85
+		skyExtinctionTint = 0.65
 	}
 }


### PR DESCRIPTION
My preferences for Scatterer Settings. Most changes just reduce the tint effect in both Map Mode and in flight.

Key universal change to look at is line 7, which rescales the scatterer effect to Earth scale in Map Mode (No giant blue bubble of Kerbin size!)
