### PR TITLE
Update EVE release link since it's no longer valid

### DIFF
--- a/Readme.txt
+++ b/Readme.txt
@@ -9,7 +9,7 @@ Requirements:
 	> http://forum.kerbalspaceprogram.com/threads/55145-1-0-4-Real-Solar-System-v10-2-July-30
 
 	Download specifically this Zip: x86-EVE-Release.zip from:
-	> https://github.com/rbray89/EnvironmentalVisualEnhancements/raw/master/x86-EVE-Release.zip
+	> https://github.com/rbray89/EnvironmentalVisualEnhancements/blob/fcc42a6c7faafbec1f8656a04e59faa86de8f8c7/x86-EVE-Release.zip?raw=true
 
 	Scatterer (Latest)
 	> http://forum.kerbalspaceprogram.com/threads/115408-WIP-Scatterer-atmospheric-scattering-(v0-0171-18-07-2015)-Kept-you-waiting-huh


### PR DESCRIPTION
Master is now for 1.1ish stuff. This fixes the link to point to the actual last working version.
